### PR TITLE
fix(config): use correct env var for Twitter (#27)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -80,7 +80,7 @@ export const runtimeConfig =
           ? process.env.GITHUB
           : process.env.RAZZLE_GITHUB,
         TWITTER: nodeIsProduction
-          ? process.env.GITHUB
+          ? process.env.TWITTER
           : process.env.RAZZLE_TWITTER,
         INSTAGRAM: nodeIsProduction
           ? process.env.INSTAGRAM


### PR DESCRIPTION
This closed #27 

env.GITHUB was used for Twitter