### PR TITLE
Fix typo in docker-compose for Soundcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ services:
       - EMAIL_TEXT=Email Me!
       - EMAIL_ALT=you@example.com
       - EMAIL_ALT_TEXT=Email me!
-      - SOUND_CLOUD=https://souncloud.com
+      - SOUND_CLOUD=https://soundcloud.com
       - FIGMA=https://figma.com
       - TELEGRAM=https://telegram.org/
       - TUMBLR=https://www.tumblr.com/


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

- Fix typo in README for soundcloud.com. This results in no functional changes as souncloud.com redirects to soundcloud.com but the latter is probably preferred.

## Checklist

- [x] Tested locally
- [x] Ran `yarn ci` to test my code
- [x] Did not add any unnecessary changes
- [x] All my changes appear after other changes in each file
- [x] Included a screenshot (if adding a new button)
- [x] 🚀

<!--- If adding a new button, please include screenshot -->
<!--- If you are adding new code, please follow the pattern and add it to the end of the file where appropriate -->
<!--- Please be sure that you are not adding any additional changes including spaces, adding/deleting lines -->
