### PR TITLE
fix(default-style): Re added default CSS class #108

### DIFF
--- a/public/css/brands.css
+++ b/public/css/brands.css
@@ -63,6 +63,12 @@ button {
 /* Brand Styles
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 
+/* Default */
+.button.button-default {
+  color: #ffffff;
+  background-color: #0085ff;
+}
+
 /* Discord */
 .button.button-discord {
   color: #ffffff;


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

- Re added default CSS class used for EMAIL buttons
- Closes #108 

<img width="256" alt="light" src="https://user-images.githubusercontent.com/30017832/157090164-1e19b144-bb1f-4d41-9f28-0b06bad201a8.png">
<img width="311" alt="dark" src="https://user-images.githubusercontent.com/30017832/157090165-4e8591c3-b5cc-40b5-8a41-dc447645f8b9.png">


## Checklist

- [x] Tested locally
- [x] Ran `yarn ci` to test my code
- [x] Did not add any unnecessary changes
- [x] All my changes appear after other changes in each file
- [x] Included a screenshot (if adding a new button)
- [x] 🚀

<!--- If adding a new button, please include screenshot -->
<!--- If you are adding new code, please follow the pattern and add it to the end of the file where appropriate -->
<!--- Please be sure that you are not adding any additional changes including spaces, adding/deleting lines -->
