### PR TITLE
fix(buttons): Fix for envs in production

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -356,16 +356,16 @@ export const runtimeConfig =
           ? process.env.KEYBASE
           : process.env.RAZZLE_KEYBASE,
         ONLYFANS: nodeIsProduction
-          ? process.env.KEYBASE
+          ? process.env.ONLYFANS
           : process.env.RAZZLE_ONLYFANS,
         SESSION: nodeIsProduction
-          ? process.env.KEYBASE
+          ? process.env.SESSION
           : process.env.RAZZLE_SESSION,
         THREEMA: nodeIsProduction
-          ? process.env.KEYBASE
+          ? process.env.THREEMA
           : process.env.RAZZLE_THREEMA,
         STREAMLABS: nodeIsProduction
-          ? process.env.KEYBASE
+          ? process.env.STREAMLABS
           : process.env.RAZZLE_STREAMLABS,
         PRIVATEBIN: nodeIsProduction
           ? process.env.PRIVATEBIN


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

- Closes #148 
- `process.env.KEYBASE` was used for `ONLYFANS`, `SESSION`, `THREEMA` and `STREAMLABS`


* When we add `KEYBASE` we don't have unwanted buttons:

<img width="250" alt="2022-06-21 190714" src="https://user-images.githubusercontent.com/30017832/174858904-2ea196a8-28fd-4eeb-97d4-be404db18a45.png">

## Checklist

- [x] Tested locally
- [x] Ran `yarn ci` to test my code
- [x] Did not add any unnecessary changes
- [x] All my changes appear after other changes in each file
- [x] Included a screenshot (if adding a new button)
- [x] 🚀

<!--- If adding a new button, please include screenshot -->
<!--- If you are adding new code, please follow the pattern and add it to the end of the file where appropriate -->
<!--- Please be sure that you are not adding any additional changes including spaces, adding/deleting lines -->
