### PR TITLE
fix(metadata): Added missing metadata for twitter #192

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -86,6 +86,8 @@ export const runtimeConfig =
         OG_IMAGE: window?.env?.OG_IMAGE,
         OG_IMAGE_WIDTH: window?.env?.OG_IMAGE_WIDTH,
         OG_IMAGE_HEIGHT: window?.env?.OG_IMAGE_HEIGHT,
+        TWITTER_TITLE: window?.env?.TWITTER_TITLE,
+        TWITTER_DESCRIPTION: window?.env?.TWITTER_DESCRIPTION,
         TWITTER_CARD: window?.env?.TWITTER_CARD,
         TWITTER_IMAGE: window?.env?.TWITTER_IMAGE,
         TWITTER_SITE: window?.env?.TWITTER_SITE,
@@ -342,6 +344,12 @@ export const runtimeConfig =
         OG_IMAGE_HEIGHT: nodeIsProduction
           ? process.env.OG_IMAGE_HEIGHT
           : process.env.RAZZLE_OG_IMAGE_HEIGHT,
+        TWITTER_TITLE: nodeIsProduction
+          ? process.env.TWITTER_TITLE
+          : process.env.RAZZLE_TWITTER_TITLE,
+        TWITTER_DESCRIPTION: nodeIsProduction
+          ? process.env.TWITTER_DESCRIPTION
+          : process.env.RAZZLE_TWITTER_DESCRIPTION,
         TWITTER_CARD: nodeIsProduction
           ? process.env.TWITTER_CARD
           : process.env.RAZZLE_TWITTER_CARD,

--- a/src/server.js
+++ b/src/server.js
@@ -122,6 +122,16 @@ server
             : ''
         }
         ${
+          runtimeConfig.TWITTER_TITLE
+            ? `<meta property="twitter:title" content="${runtimeConfig.TWITTER_TITLE}" />`
+            : ''
+        }
+        ${
+          runtimeConfig.TWITTER_DESCRIPTION
+            ? `<meta property="twitter:description" content="${runtimeConfig.TWITTER_DESCRIPTION}" />`
+            : ''
+        }
+        ${
           runtimeConfig.TWITTER_CARD
             ? `<meta property="twitter:card" content="${runtimeConfig.TWITTER_CARD}" />`
             : ''


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

- Added `twitter:title` and `twitter:description` metadata with two new env variables: `TWITTER_TITLE` and `TWITTER_DESCRIPTION` (this closes #192 )

Screenshot (If Applicable)

<img width="310" alt="image" src="https://user-images.githubusercontent.com/30017832/184535754-3a45c55d-b233-448f-9b1a-a94400a0b069.png">

_HTML generated with the new metadata_

## Checklist

- [x] Tested locally
- [x] Ran `yarn ci` to test my code
- [x] Did not add any unnecessary changes
- [x] All my changes appear after other changes in each file
- [x] Included a screenshot (if adding a new button)
- [x] 🚀

<!--- If adding a new button, please include screenshot -->
<!--- If you are adding new code, please follow the pattern and add it to the end of the file where appropriate -->
<!--- Please be sure that you are not adding any additional changes including spaces, adding/deleting lines -->
