### PR TITLE
Dynamic year in footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ services:
       - TIKTOK=https://l.technotim.live/tiktok
       - FACEBOOK=https://l.technotim.live/facebook
       - PATREON=https://l.technotim.live/patreon
-      - FOOTER=Techno Tim © 2022
+      - FOOTER=Techno Tim
     ports:
       - 8080:3000
     restart: unless-stopped
@@ -116,7 +116,7 @@ docker run -d \
   -e DISCORD='https://l.technotim.live/discord' \
   -e TIKTOK='https://l.technotim.live/discord' \
   -e KIT='https://l.technotim.live/gear' \
-  -e FOOTER=Techno Tim © 2022 \
+  -e FOOTER=Techno Tim \
   --restart unless-stopped \
   ghcr.io/techno-tim/littlelink-server:latest
 ```

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -811,7 +811,7 @@ function Home(props) {
             </Sort>
             <div>
               <p className="footer">
-                {runtimeConfig.FOOTER}
+                {runtimeConfig.FOOTER} © {new Date().getFullYear()}
                 {runtimeConfig.SHARE &&
                   runtimeConfig.OG_TITLE &&
                   runtimeConfig.OG_DESCRIPTION && (


### PR DESCRIPTION
# Proposed Changes
As footer is specified statically in config, moved copyright symbol and year outside of config.
User now only needs to specify who owns the copyright and year will update on page load.

## Checklist

- [x] Tested locally
- [x] Ran `yarn ci` to test my code
- [x] Did not add any unnecessary changes
- [x] All my changes appear after other changes in each file
- [x] Included a screenshot (if adding a new button)
- [x] 🚀