### PR TITLE
fix(Share): Added br to force break line after the text in the footer

### DIFF
--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -866,11 +866,14 @@ function Home(props) {
                 {runtimeConfig.SHARE &&
                   runtimeConfig.OG_TITLE &&
                   runtimeConfig.OG_DESCRIPTION && (
-                    <Share
-                      url={runtimeConfig.SHARE}
-                      title={runtimeConfig.OG_TITLE}
-                      text={runtimeConfig.OG_DESCRIPTION}
-                    />
+                    <>
+                      <br />
+                      <Share
+                        url={runtimeConfig.SHARE}
+                        title={runtimeConfig.OG_TITLE}
+                        text={runtimeConfig.OG_DESCRIPTION}
+                      />
+                    </>
                   )}
               </p>
             </div>


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

- When the footer is too small, the share button is not on a new line. I've added `<br />` before the Share component to force the break line.

Screenshot (If Applicable)
**Current:**
<img width="273" alt="image" src="https://user-images.githubusercontent.com/30017832/222977293-887b928b-f203-4417-b25b-537932164baf.png">


**New:**
<img width="153" alt="image" src="https://user-images.githubusercontent.com/30017832/222977229-b11fa896-5771-4785-9633-49092c8b1564.png">

## Checklist

- [x] Tested locally
- [x] Ran `yarn ci` to test my code
- [x] Did not add any unnecessary changes
- [x]] All my changes appear after other changes in each file
- [x] Included a screenshot (if adding a new button)
- [x] 🚀

<!--- If adding a new button, please include screenshot -->
<!--- If you are adding new code, please follow the pattern and add it to the end of the file where appropriate -->
<!--- Please be sure that you are not adding any additional changes including spaces, adding/deleting lines -->
