### PR TITLE
Add newer Umami script link

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Generated tracking code should look like:
 <script async defer data-website-id="00000000-1111-2222-3333-444444444444" src="https://your-umami-app.com/umami.js"></script>
 ```
 
-Use `data-website-id` as environment variable `UMAMI_WEBSITE_ID` and `src` as `UMAMI_APP_URL`.
+Use `data-website-id` as environment variable `UMAMI_WEBSITE_ID`. Take the inital root host of `src` as `UMAMI_APP_URL`, and the name of the script (i.e. `umami.js` or `script.js`) as `UMAMI_SCRIPT_NAME`.
 
 Sample event for YouTube button.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       - DEVTO=https://dev.to/
       - UMAMI_WEBSITE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
       - UMAMI_APP_URL=https://your-umami-app.com
+      - UMAMI_SCRIPT_NAME=script.js
       - BUTTON_ORDER=YOUTUBE,TWITCH,TWITTER,GITHUB,INSTAGRAM,DISCORD,FACEBOOK,TIKTOK,KIT,PATREON
       - PAYPAL=https://www.paypal.me/user
       - SLACK=https://slack.com/

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -22,7 +22,7 @@ Generated tracking code should look like:
 <script async defer data-website-id="00000000-1111-2222-3333-444444444444" src="https://your-umami-app.com/umami.js"></script>
 ```
 
-Use `data-website-id` as environment variable `UMAMI_WEBSITE_ID` and `src` as `UMAMI_APP_URL`.
+Use `data-website-id` as environment variable `UMAMI_WEBSITE_ID`. Take the inital root host of `src` as `UMAMI_APP_URL`, and the name of the script (i.e. `umami.js` or `script.js`) as `UMAMI_SCRIPT_NAME`.
 
 Sample event for YouTube button.
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 // config.js
-const nodeIsProduction = process.env.NODE_ENV === "production";
+const nodeIsProduction = process.env.NODE_ENV === 'production';
 export const runtimeConfig =
-  typeof window !== "undefined"
+  typeof window !== 'undefined'
     ? {
         // client
         META_TITLE: window?.env?.META_TITLE,

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 // config.js
-const nodeIsProduction = process.env.NODE_ENV === 'production';
+const nodeIsProduction = process.env.NODE_ENV === "production";
 export const runtimeConfig =
-  typeof window !== 'undefined'
+  typeof window !== "undefined"
     ? {
         // client
         META_TITLE: window?.env?.META_TITLE,
@@ -61,6 +61,7 @@ export const runtimeConfig =
         PATREON: window?.env?.PATREON,
         DEVTO: window?.env?.DEVTO,
         UMAMI_APP_URL: window?.env?.UMAMI_APP_URL,
+        UMAMI_SCRIPT_NAME: window?.env?.UMAMI_SCRIPT_NAME,
         BUTTON_ORDER: window?.env?.BUTTON_ORDER,
         PAYPAL: window?.env?.PAYPAL,
         SLACK: window?.env?.SLACK,
@@ -283,6 +284,9 @@ export const runtimeConfig =
         UMAMI_APP_URL: nodeIsProduction
           ? process.env.UMAMI_APP_URL
           : process.env.RAZZLE_UMAMI_APP_URL,
+        UMAMI_SCRIPT_NAME: nodeIsProduction
+          ? process.env.UMAMI_SCRIPT_NAME
+          : process.env.RAZZLE_UMAMI_SCRIPT_NAME,
         BUTTON_ORDER: nodeIsProduction
           ? process.env.BUTTON_ORDER
           : process.env.RAZZLE_BUTTON_ORDER,

--- a/src/server.js
+++ b/src/server.js
@@ -196,6 +196,9 @@ server
             ? `
             <!-- Umami Analytics -->
             <script async defer data-website-id="${runtimeConfig.UMAMI_WEBSITE_ID}" src="${runtimeConfig.UMAMI_APP_URL}/umami.js">
+            </script>
+            <!-- Newer Umami script link -->
+            <script async defer data-website-id="${runtimeConfig.UMAMI_WEBSITE_ID}" src="${runtimeConfig.UMAMI_APP_URL}/script.js">
             </script>`
             : ''
         }

--- a/src/server.js
+++ b/src/server.js
@@ -195,11 +195,8 @@ server
           runtimeConfig.UMAMI_WEBSITE_ID && runtimeConfig.UMAMI_APP_URL
             ? `
             <!-- Umami Analytics -->
-            <script async defer data-website-id="${runtimeConfig.UMAMI_WEBSITE_ID}" src="${runtimeConfig.UMAMI_APP_URL}/umami.js">
+            <script async defer data-website-id="${runtimeConfig.UMAMI_WEBSITE_ID}" src="${runtimeConfig.UMAMI_APP_URL}/${runtimeConfig.UMAMI_SCRIPT_NAME || "umami.js"}">
             </script>
-            <!-- Newer Umami script link -->
-            <script async defer data-website-id="${runtimeConfig.UMAMI_WEBSITE_ID}" src="${runtimeConfig.UMAMI_APP_URL}/script.js">
-            </script>`
             : ''
         }
         ${

--- a/src/server.js
+++ b/src/server.js
@@ -196,7 +196,7 @@ server
             ? `
             <!-- Umami Analytics -->
             <script async defer data-website-id="${runtimeConfig.UMAMI_WEBSITE_ID}" src="${runtimeConfig.UMAMI_APP_URL}/${runtimeConfig.UMAMI_SCRIPT_NAME || "umami.js"}">
-            </script>
+            </script>`
             : ''
         }
         ${

--- a/src/server.js
+++ b/src/server.js
@@ -195,7 +195,11 @@ server
           runtimeConfig.UMAMI_WEBSITE_ID && runtimeConfig.UMAMI_APP_URL
             ? `
             <!-- Umami Analytics -->
-            <script async defer data-website-id="${runtimeConfig.UMAMI_WEBSITE_ID}" src="${runtimeConfig.UMAMI_APP_URL}/${runtimeConfig.UMAMI_SCRIPT_NAME || "umami.js"}">
+            <script async defer data-website-id="${
+              runtimeConfig.UMAMI_WEBSITE_ID
+            }" src="${runtimeConfig.UMAMI_APP_URL}/${
+                runtimeConfig.UMAMI_SCRIPT_NAME || 'umami.js'
+              }">
             </script>`
             : ''
         }


### PR DESCRIPTION
# Proposed Changes
Now tries to pull `script.js` from the configured Umami provider, as `umami.js` has been replaced with that. (See [here](https://github.com/umami-software/umami/issues/1905#issue-1673108356)) Seems advisable to keep both, as some people probably haven't updated their Umami instances

An embed link from the latest Umami dashboard looks like: 
`<script async src="https://umami.example.com/script.js`<--this changed`" data-website-id="61703510-b46d-4d57-83b3-xxxxxxxx"></script>`

## Checklist

- [x] Tested locally
- [x] Ran `yarn ci` to test my code
- [x] Did not add any unnecessary changes
- [x] All my changes appear after other changes in each file
- [x] 🚀

<!--- If you are adding new code, please follow the pattern and add it to the end of the file where appropriate -->
<!--- Please be sure that you are not adding any additional changes including spaces, adding/deleting lines -->
