### PR TITLE
AVATAR_SIZE environment variable

### DIFF
--- a/src/components/App/__test__/__snapshots__/App.test.js.snap
+++ b/src/components/App/__test__/__snapshots__/App.test.js.snap
@@ -20,6 +20,7 @@ exports[`<App /> <App /> snapshot 1`] = `
       >
         <img
           className="avatar"
+          style={Object {}}
         />
         <h1>
           undefined

--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -9,20 +9,13 @@ function Avatar(props) {
   const { src, srcSet, alt } = props;
   const avatarSize = runtimeConfig.AVATAR_SIZE || null;
 
-  return avatarSize ? (
+  return (
     <img
       className={'avatar' + addShadow()}
       src={src}
       srcSet={srcSet}
       alt={alt}
-      style={{ width: avatarSize, height: avatarSize }}
-    />
-  ) : (
-    <img
-      className={'avatar' + addShadow()}
-      src={src}
-      srcSet={srcSet}
-      alt={alt}
+      style={avatarSize ? { width: avatarSize, height: avatarSize } : {}}
     />
   );
 }

--- a/src/components/Avatar/Avatar.js
+++ b/src/components/Avatar/Avatar.js
@@ -1,13 +1,23 @@
 import React, { memo } from 'react';
 import { string } from 'prop-types';
 import { addShadow } from '../../utils';
+import { runtimeConfig } from '../../config';
 
 import './Avatar.css';
 
 function Avatar(props) {
   const { src, srcSet, alt } = props;
+  const avatarSize = runtimeConfig.AVATAR_SIZE || null;
 
-  return (
+  return avatarSize ? (
+    <img
+      className={'avatar' + addShadow()}
+      src={src}
+      srcSet={srcSet}
+      alt={alt}
+      style={{ width: avatarSize, height: avatarSize }}
+    />
+  ) : (
     <img
       className={'avatar' + addShadow()}
       src={src}

--- a/src/components/Avatar/__test__/__snapshots__/Avatar.test.js.snap
+++ b/src/components/Avatar/__test__/__snapshots__/Avatar.test.js.snap
@@ -3,5 +3,6 @@
 exports[`<Avatar /> <Avatar /> snapshot 1`] = `
 <img
   className="avatar"
+  style={Object {}}
 />
 `;

--- a/src/components/Home/__test__/__snapshots__/Home.test.js.snap
+++ b/src/components/Home/__test__/__snapshots__/Home.test.js.snap
@@ -17,6 +17,7 @@ exports[`<Home /> <Home /> snapshot 1`] = `
     >
       <img
         className="avatar"
+        style={Object {}}
       />
       <h1>
         undefined

--- a/src/config.js
+++ b/src/config.js
@@ -16,6 +16,7 @@ export const runtimeConfig =
         THEME: window?.env?.THEME,
         FAVICON_URL: window?.env?.FAVICON_URL,
         AVATAR_URL: window?.env?.AVATAR_URL,
+        AVATAR_SIZE: window?.env?.AVATAR_SIZE,
         AVATAR_ALT: window?.env?.AVATAR_ALT,
         AVATAR_2X_URL: window?.env?.AVATAR_2X_URL,
         NAME: window?.env?.NAME,
@@ -183,6 +184,9 @@ export const runtimeConfig =
         AVATAR_URL: nodeIsProduction
           ? process.env.AVATAR_URL
           : process.env.RAZZLE_AVATAR_URL,
+        AVATAR_SIZE: nodeIsProduction
+          ? process.env.AVATAR_SIZE
+          : process.env.RAZZLE_AVATAR_SIZE,
         AVATAR_ALT: nodeIsProduction
           ? process.env.AVATAR_ALT
           : process.env.RAZZLE_AVATAR_ALT,


### PR DESCRIPTION
# Proposed Changes
- Add AVATAR_SIZE variable that sets the size in px. Ex: AVATAR_SIZE: 500px
Default value when variable is not set is 128px.

## Checklist

- [x] Tested locally
- [x] Ran `yarn ci` to test my code
- [x] Did not add any unnecessary changes
- [x] All my changes appear after other changes in each file
- [ ] Included a screenshot (if adding a new button)
- [x] 🚀

<!--- If adding a new button, please include screenshot -->
<!--- If you are adding new code, please follow the pattern and add it to the end of the file where appropriate -->
<!--- Please be sure that you are not adding any additional changes including spaces, adding/deleting lines -->
