### PR TITLE
fix(docker): add openssl-legacy-provider for Node 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,13 @@ COPY yarn.lock ./
 COPY src ./src
 COPY public ./public
 RUN yarn install --frozen-lockfile --check-files --network-timeout 600000
-RUN yarn build --noninteractive
+RUN NODE_OPTIONS=--openssl-legacy-provider yarn build --noninteractive
 RUN yarn install --frozen-lockfile --check-files --production --modules-folder node_modules_prod --network-timeout 600000
 
 FROM node:24.18.0-alpine
 WORKDIR /usr/src/app
-ENV NODE_ENV production
+ENV NODE_ENV=production
+ENV NODE_OPTIONS=--openssl-legacy-provider
 RUN mkdir -p /node_modules
 COPY --from=node-build /usr/src/app/build ./build
 COPY --from=node-build /usr/src/app/node_modules_prod ./node_modules
@@ -18,4 +19,3 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:3000/healthcheck || exit 1
 CMD [ "node", "build/server.js" ]
-


### PR DESCRIPTION
## Summary

Fix ERR\_OSSL\_EVP\_UNSUPPORTED error in Docker build when using Node 24.

### Changes
- Add `NODE_OPTIONS=--openssl-legacy-provider` to build step
- Add `ENV NODE_OPTIONS=--openssl-legacy-provider` for runtime
- Fix ENV syntax from `ENV key value` to `ENV key=value` format

### Verification
- `yarn start` - compiles successfully
- `yarn ci` - all 8 test suites pass