### PR TITLE
fix(build): Verify Docker build and patch failures

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,3 +24,6 @@ jobs:
         yarn ci
       env:
         CI: true
+
+    - name: Build Docker image
+      run: docker build --tag littlelink-server:pr .

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY src ./src
 COPY public ./public
 RUN yarn install --frozen-lockfile --check-files --network-timeout 600000
 RUN yarn build --noninteractive
-RUN yarn install --frozen-lockfile --check-files --production --modules-folder node_modules_prod --network-timeout 600000
+RUN yarn install --frozen-lockfile --check-files --production --ignore-scripts --modules-folder node_modules_prod --network-timeout 600000
 
 FROM node:24.18.0-alpine
 WORKDIR /usr/src/app
@@ -19,4 +19,3 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:3000/healthcheck || exit 1
 CMD [ "node", "build/server.js" ]
-

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start:prod": "NODE_ENV=production node build/server.js",
     "lint": "eslint .",
     "lint:style": "stylelint ./src/**/*.css ./public/**/*.css",
-    "postinstall": "command -v patch-package >/dev/null 2>&1 && patch-package || true",
+    "postinstall": "patch-package",
     "ci": "yarn lint && yarn lint:style && yarn lint:markdown && yarn test",
     "lint:markdown": "markdownlint .github/*.md && markdownlint README.md"
   },


### PR DESCRIPTION
## Summary

Follow up on #835 by making the dependency patch lifecycle fail loudly and adding Docker build coverage to pull request CI.

## Changes

- Replace the shell-specific, error-swallowing `postinstall` command with the standard `patch-package` command
- Skip lifecycle scripts only during the production-only Docker dependency install, where `patch-package` is intentionally unavailable
- Build the Docker image in the pull request workflow so the Node 24/OpenSSL compatibility path is exercised before merge

## Why

The previous `postinstall` command ended with `|| true`, which could hide a stale or failed patch. The existing pull request workflow also did not run `yarn build` or build the Dockerfile, so it did not directly verify the issue fixed by #835.

## Validation

The pull request workflow will run the existing lint and test suite, then build the Docker image.