### PR TITLE
fix(layout): keep mobile buttons centered

### DIFF
--- a/e2e/full-env.spec.ts
+++ b/e2e/full-env.spec.ts
@@ -98,6 +98,38 @@ test.describe('Full featured compose example', () => {
     await expect(page.getByText('Recommended Gear')).toBeVisible();
   });
 
+  test('mobile layout stays centered without horizontal overflow', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 320, height: 900 });
+    await page.goto('/', { waitUntil: 'networkidle' });
+
+    const pageWidth = await page.evaluate(
+      () => document.documentElement.clientWidth,
+    );
+    const scrollWidth = await page.evaluate(
+      () => document.documentElement.scrollWidth,
+    );
+
+    expect(scrollWidth).toBeLessThanOrEqual(pageWidth);
+
+    const viewportCenter = pageWidth / 2;
+    const avatar = await page.locator('img.avatar').boundingBox();
+    const title = await page.locator('h1').boundingBox();
+    const firstButton = await page.locator('a.button').first().boundingBox();
+
+    expect(avatar).not.toBeNull();
+    expect(title).not.toBeNull();
+    expect(firstButton).not.toBeNull();
+
+    for (const box of [avatar, title, firstButton]) {
+      const center = box!.x + box!.width / 2;
+      expect(Math.abs(center - viewportCenter)).toBeLessThanOrEqual(2);
+    }
+
+    expect(firstButton!.width).toBeLessThan(300);
+  });
+
   test('avatar image renders with correct alt text', async ({ page }) => {
     await page.goto('/', { waitUntil: 'networkidle' });
     const avatar = page.locator('img').first();

--- a/public/css/brands.css
+++ b/public/css/brands.css
@@ -31,19 +31,25 @@
 
 .button,
 button {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   margin-left: auto;
   margin-right: auto;
   text-decoration: none;
-  height: 48px;
+  min-height: 48px;
+  padding: 10px 16px;
   text-align: center;
   vertical-align: middle;
   font-size: 18px;
-  width: 300px;
+  width: min(300px, 100%);
+  max-width: 100%;
+  box-sizing: border-box;
   font-weight: 700;
-  line-height: 48px;
+  line-height: 1.2;
   letter-spacing: 0.1px;
-  white-space: wrap;
+  white-space: normal;
+  overflow-wrap: anywhere;
   border-radius: 8px;
   cursor: pointer;
 }
@@ -56,7 +62,9 @@ button {
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 
 .icon {
-  padding: 0px 8px 3.5px 0px;
+  flex-shrink: 0;
+  margin-right: 8px;
+  padding: 0;
   vertical-align: middle;
   width: 20px;
   height: 20px;

--- a/src/__tests__/styles/buttonStyles.test.ts
+++ b/src/__tests__/styles/buttonStyles.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const brandsCss = readFileSync(
+  join(process.cwd(), 'public/css/brands.css'),
+  'utf8',
+);
+
+function cssBlock(selector: RegExp): string {
+  const match = brandsCss.match(selector);
+  if (!match) {
+    throw new Error('Expected CSS block was not found');
+  }
+  return match[1];
+}
+
+describe('button responsive styles', () => {
+  test('buttons shrink inside narrow containers and center their content', () => {
+    const buttonRules = cssBlock(/\.button,\s*button\s*\{([\s\S]*?)\n\}/);
+
+    expect(buttonRules).toContain('display: flex;');
+    expect(buttonRules).toContain('align-items: center;');
+    expect(buttonRules).toContain('justify-content: center;');
+    expect(buttonRules).toContain('width: min(300px, 100%);');
+    expect(buttonRules).toContain('max-width: 100%;');
+    expect(buttonRules).toContain('box-sizing: border-box;');
+    expect(buttonRules).not.toContain('width: 300px;');
+  });
+
+  test('button icons keep stable dimensions in flexible buttons', () => {
+    const iconRules = cssBlock(/\.icon\s*\{([\s\S]*?)\n\}/);
+
+    expect(iconRules).toContain('flex-shrink: 0;');
+    expect(iconRules).toContain('width: 20px;');
+    expect(iconRules).toContain('height: 20px;');
+  });
+});


### PR DESCRIPTION
# Proposed Changes

- Make LittleLink buttons responsive on narrow screens by capping width at 300px while allowing them to shrink to the container width.
- Center button icons and labels together with flex layout so the avatar, heading, bio, and buttons stay aligned on mobile.
- Add unit and e2e regression coverage for responsive button styles, horizontal overflow, and mobile centering.

closes https://github.com/timothystewart6/littlelink-server/issues/789
closes https://github.com/timothystewart6/littlelink-server/issues/78

Screenshot (If Applicable)

N/A

## Checklist

- [x] Tested locally
- [x] Ran `yarn ci` to test my code
- [x] Ran `yarn typecheck` to verify types
- [x] Ran `yarn test:e2e` to verify e2e tests
- [x] Did not add any unnecessary changes
- [x] All my changes appear after other changes in each file
- [x] Included a screenshot (if adding a new button)
- [x] 🚀

## Validation

- `yarn test --runTestsByPath src/__tests__/styles/buttonStyles.test.ts`
- `yarn playwright test --config=playwright.config.ts --project=chromium --reporter=list -g "mobile layout stays centered"`
- `yarn ci`
- `yarn playwright test --config=playwright.config.ts --project=chromium --reporter=list`
