### PR TITLE
feat(sitemap): add runtime sitemap route

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ If you use VS Code, set the workspace TypeScript version:
 
 Environment values are always strings and are read at **request time**, not at build time. No `NEXT_PUBLIC_` prefix or `env` block is needed. Changes take effect after a container restart without rebuilding the image.
 
+### Sitemap
+
+LittleLink-Server exposes `/sitemap.xml` when `OG_URL` is configured and `META_INDEX_STATUS` allows indexing. The sitemap contains the single public profile URL and is generated at request time from environment variables.
+
+```bash
+OG_URL=https://links.example.com
+META_INDEX_STATUS=all
+```
+
+If `OG_URL` is not set, or `META_INDEX_STATUS` contains `noindex`, `/sitemap.xml` returns `404`.
+
 ### Docker build
 
 ```bash

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { getRuntimeConfig } from '../../src/config/runtimeConfig';
+import {
+  buildSitemapXml,
+  getSitemapLocation,
+} from '../../src/sitemap/sitemapXml';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<NextResponse> {
+  const location = getSitemapLocation(getRuntimeConfig());
+
+  if (!location) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  return new NextResponse(buildSitemapXml(location), {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+    },
+  });
+}

--- a/e2e/full-env.spec.ts
+++ b/e2e/full-env.spec.ts
@@ -173,6 +173,18 @@ test.describe('Full featured compose example', () => {
     await expect(favicon).toHaveAttribute('href', ENV.FAVICON_URL!);
   });
 
+  test('sitemap uses configured public URL', async ({ page }) => {
+    const response = await page.request.get('/sitemap.xml');
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toContain('application/xml');
+
+    const body = await response.text();
+    expect(body).toContain('<urlset');
+    expect(body).toContain(`<loc>${ENV.OG_URL}/</loc>`);
+    expect(body).toContain('<changefreq>weekly</changefreq>');
+    expect(body).toContain('<priority>1.0</priority>');
+  });
+
   test('healthcheck returns 200 and status ok', async ({ page }) => {
     const response = await page.request.get('/healthcheck');
     expect(response.status()).toBe(200);

--- a/e2e/minimal-env.spec.ts
+++ b/e2e/minimal-env.spec.ts
@@ -45,4 +45,9 @@ test.describe('Minimal env (no variables set)', () => {
     const body = await response.json();
     expect(body).toEqual({ status: 'ok' });
   });
+
+  test('sitemap is not published without a public URL', async ({ page }) => {
+    const response = await page.request.get('/sitemap.xml');
+    expect(response.status()).toBe(404);
+  });
 });

--- a/src/__tests__/sitemap/sitemapXml.test.ts
+++ b/src/__tests__/sitemap/sitemapXml.test.ts
@@ -1,0 +1,63 @@
+import {
+  buildSitemapXml,
+  getSitemapLocation,
+  isSitemapIndexable,
+  normalizeSitemapUrl,
+} from '../../sitemap/sitemapXml';
+
+describe('sitemap XML helpers', () => {
+  test('uses OG_URL when indexing is enabled', () => {
+    expect(
+      getSitemapLocation({
+        META_INDEX_STATUS: 'all',
+        OG_URL: 'https://links.example.com',
+      }),
+    ).toBe('https://links.example.com/');
+  });
+
+  test('does not publish a sitemap URL when indexing is disabled', () => {
+    expect(
+      getSitemapLocation({
+        META_INDEX_STATUS: 'noindex',
+        OG_URL: 'https://links.example.com',
+      }),
+    ).toBeUndefined();
+  });
+
+  test('does not publish a sitemap URL without an OG_URL', () => {
+    expect(
+      getSitemapLocation({ META_INDEX_STATUS: 'all', OG_URL: undefined }),
+    ).toBeUndefined();
+  });
+
+  test('normalizes public http and https URLs', () => {
+    expect(normalizeSitemapUrl(' https://example.com/profile ')).toBe(
+      'https://example.com/profile/',
+    );
+    expect(normalizeSitemapUrl('http://example.com/#section')).toBe(
+      'http://example.com/',
+    );
+  });
+
+  test('rejects invalid or unsupported URLs', () => {
+    expect(normalizeSitemapUrl('not a url')).toBeUndefined();
+    expect(normalizeSitemapUrl('mailto:test@example.com')).toBeUndefined();
+  });
+
+  test('requires an explicit indexable status', () => {
+    expect(isSitemapIndexable(undefined)).toBe(false);
+    expect(isSitemapIndexable('all')).toBe(true);
+    expect(isSitemapIndexable('index,follow')).toBe(true);
+    expect(isSitemapIndexable('noindex,nofollow')).toBe(false);
+  });
+
+  test('escapes sitemap locations in XML output', () => {
+    const xml = buildSitemapXml('https://example.com/?name=Tom&title="Owner"');
+
+    expect(xml).toContain(
+      '<loc>https://example.com/?name=Tom&amp;title=&quot;Owner&quot;</loc>',
+    );
+    expect(xml).toContain('<changefreq>weekly</changefreq>');
+    expect(xml).toContain('<priority>1.0</priority>');
+  });
+});

--- a/src/sitemap/sitemapXml.ts
+++ b/src/sitemap/sitemapXml.ts
@@ -1,0 +1,66 @@
+import type { RuntimeConfig } from '../config/runtimeConfig';
+
+const CHANGE_FREQUENCY = 'weekly';
+const PRIORITY = '1.0';
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export function isSitemapIndexable(
+  metaIndexStatus: string | undefined,
+): boolean {
+  if (!metaIndexStatus) {
+    return false;
+  }
+  return !metaIndexStatus.toLowerCase().includes('noindex');
+}
+
+export function normalizeSitemapUrl(
+  value: string | undefined,
+): string | undefined {
+  if (!value?.trim()) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return undefined;
+    }
+
+    url.hash = '';
+    if (!url.pathname.endsWith('/')) {
+      url.pathname = `${url.pathname}/`;
+    }
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+export function getSitemapLocation(
+  config: Pick<RuntimeConfig, 'META_INDEX_STATUS' | 'OG_URL'>,
+): string | undefined {
+  if (!isSitemapIndexable(config.META_INDEX_STATUS)) {
+    return undefined;
+  }
+  return normalizeSitemapUrl(config.OG_URL);
+}
+
+export function buildSitemapXml(location: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>${escapeXml(location)}</loc>
+    <changefreq>${CHANGE_FREQUENCY}</changefreq>
+    <priority>${PRIORITY}</priority>
+  </url>
+</urlset>
+`;
+}


### PR DESCRIPTION
# Proposed Changes

- Add a dynamic `/sitemap.xml` route generated from runtime environment configuration.
- Use existing `OG_URL` as the public sitemap location and respect `META_INDEX_STATUS` when it contains `noindex`.
- Document sitemap behavior and add unit plus e2e coverage for configured and minimal environments.

Screenshot (If Applicable)

N/A

## Checklist

- [x] Tested locally
- [x] Ran `yarn ci` to test my code
- [x] Ran `yarn typecheck` to verify types
- [x] Ran `yarn test:e2e` to verify e2e tests
- [x] Did not add any unnecessary changes
- [x] All my changes appear after other changes in each file
- [x] Included a screenshot (if adding a new button)
- [x] 🚀

## Validation

- `yarn test --runTestsByPath src/__tests__/sitemap/sitemapXml.test.ts`
- `yarn playwright test --config=playwright.config.ts --project=chromium --reporter=list -g "sitemap uses configured public URL"`
- `yarn ci`
- `yarn playwright test --config=playwright.config.ts --project=chromium --reporter=list`
- `docker build --tag littlelink-server:sitemap-test . && IMAGE_NAME=littlelink-server:sitemap-test bash e2e/minimal-env.sh`
