### PR TITLE
feat(robots): add runtime robots configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,27 @@ META_INDEX_STATUS=all
 
 If `OG_URL` is not set, or `META_INDEX_STATUS` contains `noindex`, `/sitemap.xml` returns `404`.
 
+### Robots
+
+LittleLink-Server generates `/robots.txt` at request time. By default, `META_INDEX_STATUS=all` allows crawling and adds a sitemap link when `OG_URL` is configured. Missing or `noindex` metadata disallows crawling.
+
+```bash
+META_INDEX_STATUS=all
+OG_URL=https://links.example.com
+```
+
+Use `ROBOTS_ADDITIONAL_RULES` to append crawler-specific rules. Escaped `\n` sequences are converted to new lines, which works well in container environment variables.
+
+```bash
+ROBOTS_ADDITIONAL_RULES=User-agent: GPTBot\nDisallow: /\n\nUser-agent: Googlebot\nDisallow: /
+```
+
+Use `ROBOTS_TXT` when you need to replace the generated file entirely.
+
+```bash
+ROBOTS_TXT=User-agent: *\nDisallow: /private
+```
+
 ### Docker build
 
 ```bash

--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { getRuntimeConfig } from '../../src/config/runtimeConfig';
+import { buildRobotsTxt } from '../../src/robots/robotsTxt';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<NextResponse> {
+  return new NextResponse(buildRobotsTxt(getRuntimeConfig()), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+}

--- a/e2e/full-env.spec.ts
+++ b/e2e/full-env.spec.ts
@@ -25,6 +25,7 @@ const ENV: Record<string, string> = {
   OG_IMAGE_WIDTH: '400',
   OG_IMAGE_HEIGHT: '400',
   GA_TRACKING_ID: 'G-XXXXXXXXXX',
+  ROBOTS_ADDITIONAL_RULES: 'User-agent: GPTBot\\nDisallow: /',
   THEME: 'Dark',
   FAVICON_URL:
     'https://pbs.twimg.com/profile_images/1286144221217316864/qIAsKOpB_200x200.jpg',
@@ -183,6 +184,19 @@ test.describe('Full featured compose example', () => {
     expect(body).toContain(`<loc>${ENV.OG_URL}/</loc>`);
     expect(body).toContain('<changefreq>weekly</changefreq>');
     expect(body).toContain('<priority>1.0</priority>');
+  });
+
+  test('robots allows indexing, links sitemap, and appends custom rules', async ({
+    page,
+  }) => {
+    const response = await page.request.get('/robots.txt');
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toContain('text/plain');
+
+    const body = await response.text();
+    expect(body).toContain('User-agent: *\nAllow: /');
+    expect(body).toContain('User-agent: GPTBot\nDisallow: /');
+    expect(body).toContain(`Sitemap: ${ENV.OG_URL}/sitemap.xml`);
   });
 
   test('healthcheck returns 200 and status ok', async ({ page }) => {

--- a/e2e/minimal-env.spec.ts
+++ b/e2e/minimal-env.spec.ts
@@ -50,4 +50,12 @@ test.describe('Minimal env (no variables set)', () => {
     const response = await page.request.get('/sitemap.xml');
     expect(response.status()).toBe(404);
   });
+
+  test('robots disallows crawling by default', async ({ page }) => {
+    const response = await page.request.get('/robots.txt');
+    expect(response.status()).toBe(200);
+
+    const body = await response.text();
+    expect(body).toBe('User-agent: *\nDisallow: /\n');
+  });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
           OG_IMAGE_WIDTH: '400',
           OG_IMAGE_HEIGHT: '400',
           GA_TRACKING_ID: 'G-XXXXXXXXXX',
+          ROBOTS_ADDITIONAL_RULES: 'User-agent: GPTBot\\nDisallow: /',
           THEME: 'Dark',
           FAVICON_URL:
             'https://pbs.twimg.com/profile_images/1286144221217316864/qIAsKOpB_200x200.jpg',

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-

--- a/src/__tests__/config/runtimeConfig.test.ts
+++ b/src/__tests__/config/runtimeConfig.test.ts
@@ -126,7 +126,7 @@ describe('shouldSkipHealthLog', () => {
 
 describe('ENV_NAMES allowlist', () => {
   test('contains exactly the expected number of keys', () => {
-    expect(ENV_NAMES.length).toBe(165);
+    expect(ENV_NAMES.length).toBe(167);
   });
 
   test('every key is sorted alphabetically', () => {

--- a/src/__tests__/robots/robotsTxt.test.ts
+++ b/src/__tests__/robots/robotsTxt.test.ts
@@ -1,0 +1,50 @@
+import { buildRobotsTxt } from '../../robots/robotsTxt';
+
+describe('buildRobotsTxt', () => {
+  test('allows indexable pages and links to the sitemap', () => {
+    expect(
+      buildRobotsTxt({
+        META_INDEX_STATUS: 'all',
+        OG_URL: 'https://links.example.com',
+      }),
+    ).toBe(
+      'User-agent: *\nAllow: /\n\nSitemap: https://links.example.com/sitemap.xml\n',
+    );
+  });
+
+  test('disallows crawling when indexing is disabled', () => {
+    expect(
+      buildRobotsTxt({
+        META_INDEX_STATUS: 'noindex',
+        OG_URL: 'https://links.example.com',
+      }),
+    ).toBe('User-agent: *\nDisallow: /\n');
+  });
+
+  test('disallows crawling when index status is not configured', () => {
+    expect(buildRobotsTxt({})).toBe('User-agent: *\nDisallow: /\n');
+  });
+
+  test('appends crawler-specific additional rules', () => {
+    expect(
+      buildRobotsTxt({
+        META_INDEX_STATUS: 'all',
+        OG_URL: 'https://links.example.com',
+        ROBOTS_ADDITIONAL_RULES:
+          'User-agent: GPTBot\\nDisallow: /\\n\\nUser-agent: Googlebot\\nDisallow: /',
+      }),
+    ).toBe(
+      'User-agent: *\nAllow: /\n\nUser-agent: GPTBot\nDisallow: /\n\nUser-agent: Googlebot\nDisallow: /\n\nSitemap: https://links.example.com/sitemap.xml\n',
+    );
+  });
+
+  test('uses ROBOTS_TXT as a full override', () => {
+    expect(
+      buildRobotsTxt({
+        META_INDEX_STATUS: 'all',
+        OG_URL: 'https://links.example.com',
+        ROBOTS_TXT: 'User-agent: *\\nDisallow: /private',
+      }),
+    ).toBe('User-agent: *\nDisallow: /private\n');
+  });
+});

--- a/src/config/envNames.ts
+++ b/src/config/envNames.ts
@@ -119,6 +119,8 @@ export const ENV_NAMES = Object.freeze([
   'PRIVATEBIN',
   'PRODUCT_HUNT',
   'REDDIT',
+  'ROBOTS_ADDITIONAL_RULES',
+  'ROBOTS_TXT',
   'RSS',
   'SEMANTICSCHOLAR',
   'SERIALIZD',

--- a/src/robots/robotsTxt.ts
+++ b/src/robots/robotsTxt.ts
@@ -1,0 +1,61 @@
+import type { RuntimeConfig } from '../config/runtimeConfig';
+import { getSitemapLocation, isSitemapIndexable } from '../sitemap/sitemapXml';
+
+type RobotsConfig = Partial<
+  Pick<
+    RuntimeConfig,
+    'META_INDEX_STATUS' | 'OG_URL' | 'ROBOTS_ADDITIONAL_RULES' | 'ROBOTS_TXT'
+  >
+>;
+
+function normalizeRobotsText(value: string | undefined): string | undefined {
+  if (!value?.trim()) {
+    return undefined;
+  }
+
+  const normalized = value
+    .replace(/\\n/g, '\n')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .trim();
+
+  return `${normalized}\n`;
+}
+
+function getSitemapIndexUrl(config: RobotsConfig): string | undefined {
+  const location = getSitemapLocation({
+    META_INDEX_STATUS: config.META_INDEX_STATUS,
+    OG_URL: config.OG_URL,
+  });
+  if (!location) {
+    return undefined;
+  }
+  return new URL('/sitemap.xml', location).toString();
+}
+
+export function buildRobotsTxt(config: RobotsConfig): string {
+  const override = normalizeRobotsText(config.ROBOTS_TXT);
+  if (override) {
+    return override;
+  }
+
+  const lines = ['User-agent: *'];
+  if (isSitemapIndexable(config.META_INDEX_STATUS)) {
+    lines.push('Allow: /');
+  } else {
+    lines.push('Disallow: /');
+  }
+
+  const sections = [lines.join('\n')];
+  const additionalRules = normalizeRobotsText(config.ROBOTS_ADDITIONAL_RULES);
+  if (additionalRules) {
+    sections.push(additionalRules.trim());
+  }
+
+  const sitemapUrl = getSitemapIndexUrl(config);
+  if (sitemapUrl) {
+    sections.push(`Sitemap: ${sitemapUrl}`);
+  }
+
+  return `${sections.join('\n\n')}\n`;
+}


### PR DESCRIPTION
# Proposed Changes

- Replace the static `public/robots.txt` with a dynamic `/robots.txt` route generated from runtime configuration.
- Add `ROBOTS_ADDITIONAL_RULES` for crawler-specific rules, including AI training or search crawler restrictions.
- Add `ROBOTS_TXT` as a full robots file override for advanced policies.
- Keep default behavior aligned with `META_INDEX_STATUS` and include a sitemap link when `OG_URL` is configured and indexing is enabled.
- Document robots configuration and add unit plus e2e coverage.

closes https://github.com/timothystewart6/littlelink-server/issues/244

Screenshot (If Applicable)

N/A

## Checklist

- [x] Tested locally
- [x] Ran `yarn ci` to test my code
- [x] Ran `yarn typecheck` to verify types
- [x] Ran `yarn test:e2e` to verify e2e tests
- [x] Did not add any unnecessary changes
- [x] All my changes appear after other changes in each file
- [x] Included a screenshot (if adding a new button)
- [x] 🚀

## Validation

- `yarn test --runTestsByPath src/__tests__/robots/robotsTxt.test.ts src/__tests__/config/runtimeConfig.test.ts`
- `yarn playwright test --config=playwright.config.ts --project=chromium --reporter=list -g "robots allows indexing"`
- `yarn ci`
- `yarn playwright test --config=playwright.config.ts --project=chromium --reporter=list`
- `docker build --tag littlelink-server:robots-test . && IMAGE_NAME=littlelink-server:robots-test bash e2e/minimal-env.sh`
