### PR TITLE
fix(docker): use IPv4 loopback for healthcheck

### DIFF
--- a/.github/workflows/install-test-build.yml
+++ b/.github/workflows/install-test-build.yml
@@ -50,5 +50,6 @@ jobs:
             littlelink-server:pr
           trap 'docker stop littlelink-pr 2>/dev/null' EXIT
           sleep 3
+          bash src/container-health-test.sh littlelink-pr
           curl -s -o /dev/null -w "healthcheck: %{http_code}\\n" http://localhost:3100/healthcheck
           curl -s -o /dev/null -w "root: %{http_code}\\n" http://localhost:3100/

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,5 @@ COPY --from=node-build --chown=node:node /usr/src/app/public ./public
 USER node
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:3000/healthcheck || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:3000/healthcheck || exit 1
 CMD [ "node", "server.js" ]

--- a/src/container-health-test.sh
+++ b/src/container-health-test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Verify the image's built-in Docker healthcheck.
+# Usage: ./src/container-health-test.sh [container-name] [timeout-seconds]
+
+set -u
+
+CONTAINER_NAME="${1:-littlelink-pr}"
+TIMEOUT_SECONDS="${2:-90}"
+START_TIME=$(date +%s)
+
+echo "=== Container healthcheck test ==="
+echo "Container: $CONTAINER_NAME"
+
+while true; do
+  STATUS=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}no-healthcheck{{end}}' "$CONTAINER_NAME" 2>/dev/null || true)
+
+  case "$STATUS" in
+    healthy)
+      echo "PASS  Docker healthcheck is healthy"
+      exit 0
+      ;;
+    unhealthy|no-healthcheck)
+      echo "FAIL  Docker healthcheck status: $STATUS"
+      docker inspect --format '{{json .State.Health}}' "$CONTAINER_NAME" 2>/dev/null || true
+      exit 1
+      ;;
+  esac
+
+  if [ $(( $(date +%s) - START_TIME )) -ge "$TIMEOUT_SECONDS" ]; then
+    echo "FAIL  Docker healthcheck did not become healthy within ${TIMEOUT_SECONDS}s"
+    docker inspect --format '{{json .State.Health}}' "$CONTAINER_NAME" 2>/dev/null || true
+    exit 1
+  fi
+
+  sleep 2
+done


### PR DESCRIPTION
## Summary

- Change the Docker healthcheck from `localhost` to `127.0.0.1`.
- Add a regression test that verifies the container reaches Docker health status `healthy`.
- Run the regression test in the pull request Docker smoke-test workflow.

## Root cause

Alpine `wget` resolves `localhost` to IPv6 `::1`, while the application listens on IPv4 `0.0.0.0:3000`. The built-in healthcheck therefore fails even though `/healthcheck` returns HTTP 200.

## Validation

- Built the image locally.
- Confirmed the patched container becomes healthy.
- Confirmed `/healthcheck` returns `{"status":"ok"}`.

Closes #854.